### PR TITLE
Add trivago

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Mir fallen gerade nicht all ein
 * Lieferando
 * Opodo
 * Swoodoo
+* trivago
 * Zalando
 
 Es gibt noch mehr, die fallen mir nur gerade nicht ein, ich schau zu wenig Fern


### PR DESCRIPTION
(Yes, it's always written lowercase - even used in a list or at the beginning of a sentence.)